### PR TITLE
npm package workaround

### DIFF
--- a/packages/react/webpack.config.js
+++ b/packages/react/webpack.config.js
@@ -21,6 +21,14 @@ module.exports = function config({ config: webpackConfig }) {
     });
   }
 
+  // Workaround for npm's fs package
+  webpackConfig.node = {
+    console: true,
+    fs: "empty",
+    net: "empty",
+    tls: "empty"
+  }
+  
   // Define the paths that exemplar will attempt to load
   webpackConfig.plugins.push(new DefinePlugin(definitions));
 


### PR DESCRIPTION
Using certain npm modules produces strange errors despite being installed in package.json or package-lock.json (see: https://github.com/peaksandpies/universal-analytics/issues/58). Adding this block in the webpack config allows storybook to ignore the version conflicts.