### PR TITLE
fix: remove addons method for Storbook 5.x

### DIFF
--- a/packages/exemplar-storybook-react/CHANGELOG.md
+++ b/packages/exemplar-storybook-react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- [MAJOR] Remove `addons` method as Storybook 5.x behaves differently with addons.
+
 ### 1.1.1
 
 - Add missing `dependencies`.

--- a/packages/exemplar-storybook-react/index.js
+++ b/packages/exemplar-storybook-react/index.js
@@ -101,24 +101,3 @@ exports.config = function config(entry = []) {
 
   return [...entry, ...allConfigs];
 };
-
-exports.addons = function addons(entry = []) {
-  let addons;
-
-  //
-  // Remark (indexzero): could optionally attempt
-  // to load `configDir/addons.js` here to be less
-  // confusing to newcomers more familiar with Storybook
-  // itself.
-  //
-  const fullpath = definitions.EX_SETUP_ADDONS;
-  try {
-    // TODO: remove ugly hack. Normalize internal data structures
-    addons = require.resolve(fullpath.replace(/'/g, ''));
-  } catch (ex) {
-    debug(`Error loading addons ${fullpath}:`, ex);
-    return entry;
-  }
-
-  return [...entry, addons];
-};


### PR DESCRIPTION
When running Storybook 5.3, I ran into an issue with this method being passed in where Storybook actually expects an array of presets. Removing this method enables Storybook to build and render as expected.

See the Storybook docs where `addons` was changed: https://storybook.js.org/docs/presets/introduction/#basic-usage

Based on what I'm seeing in the docs I'd assume this is a breaking change.