### PR TITLE
Lock storybook and downgrade sass-loader

### DIFF
--- a/packages/exemplar-storybook-react/CHANGELOG.md
+++ b/packages/exemplar-storybook-react/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- [MAJOR] Remove `addons` method as Storybook 5.x behaves differently with addons.
+
 ### 1.1.1
 
 - Add missing `dependencies`.

--- a/packages/exemplar-storybook-react/CHANGELOG.md
+++ b/packages/exemplar-storybook-react/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 - [MAJOR] Remove `addons` method as Storybook 5.x behaves differently with addons.
+- Lock storybook to `5.2.8` and `sass-loader` at `7.x`.
 
 ### 1.1.1
 

--- a/packages/exemplar-storybook-react/index.js
+++ b/packages/exemplar-storybook-react/index.js
@@ -101,24 +101,3 @@ exports.config = function config(entry = []) {
 
   return [...entry, ...allConfigs];
 };
-
-exports.addons = function addons(entry = []) {
-  let addons;
-
-  //
-  // Remark (indexzero): could optionally attempt
-  // to load `configDir/addons.js` here to be less
-  // confusing to newcomers more familiar with Storybook
-  // itself.
-  //
-  const fullpath = definitions.EX_SETUP_ADDONS;
-  try {
-    // TODO: remove ugly hack. Normalize internal data structures
-    addons = require.resolve(fullpath.replace(/'/g, ''));
-  } catch (ex) {
-    debug(`Error loading addons ${fullpath}:`, ex);
-    return entry;
-  }
-
-  return [...entry, addons];
-};

--- a/packages/exemplar-storybook-react/package.json
+++ b/packages/exemplar-storybook-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exemplar/storybook-react",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Documentation Rocket Fuel for your components using Storybook.",
   "main": "index.js",
   "scripts": {
@@ -35,7 +35,7 @@
     "css-loader": "^3.2.0",
     "diagnostics": "^1.1.1",
     "node-sass": "^4.13.0",
-    "sass-loader": "^8.0.0",
+    "sass-loader": "^7.3.1",
     "style-loader": "^1.0.0",
     "webpack": "^4.28.4"
   },
@@ -50,7 +50,7 @@
     "@babel/core": "^7.4.5",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@storybook/addons": "^5.1.9",
-    "@storybook/react": "^5.1.0",
+    "@storybook/react": "5.2.8",
     "assume": "^2.2.0",
     "babel-eslint": "^10.0.2",
     "eslint": "^5.14.1",


### PR DESCRIPTION
This locks storybook at `5.2.8` and downgrades `sass-loader` to `7.x`. Our presets do not work with storybook `5.3.x` and UXCore does not (and will not) work with `node-sass` `8.x`.

UXCore has been locked to storybook `5.2.8` for `1999` release.